### PR TITLE
Increase initial login timeout yet further, 240 seconds

### DIFF
--- a/cypress/integration/ldp/01-basics.js
+++ b/cypress/integration/ldp/01-basics.js
@@ -24,7 +24,7 @@ describe('ui-ldp: application exists', () => {
       // But it's not feasible to log in to Stipes using a similar
       // behind-the-scenes approach, so we have to use the UI.
       // Looong timeout since we have to wait for the Stripes bundle to build
-      cy.visit('', { timeout: 120000 })
+      cy.visit('', { timeout: 240000 })
       cy.contains('Log in')
       cy.get('#input-username').type('diku_admin')
       cy.get('#input-password').type('admin')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "stripes serve stripes.config.js",
     "build": "stripes build --output ./output",
-    "test": "stripes serve --coverage --port 3001 --okapi https://folio-snapshot-okapi.dev.folio.org & pid=$! && cypress run; status=$?; kill $pid; echo Exiting with status $status; exit $status",
+    "test": "stripes serve --coverage --port 3001 --okapi https://folio-snapshot-okapi.dev.folio.org & pid=$! && sleep 40 && cypress run; status=$?; kill $pid; echo Exiting with status $status; exit $status",
     "coverage-summary": "nyc report --reporter=text-summary",
     "coverage": "nyc report --reporter=text",
     "lint": "eslint --format unix .",


### PR DESCRIPTION
Because sometimes the Stripes bundle takes a looong time to build.