### PR TITLE
Move from `library-data-platform` to `folio-org` complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [1.5.0](https://github.com/folio-org/ui-ldp/tree/v1.5.0) (IN PROGRESS)
 
-* Add [`PERSONAL_DATA_DISCLOSURE.md`](PERSONAL_DATA_DISCLOSURE.md) file.
+* Repair tests, which had broken due to changes in Stripes. Fixes UILDP-3.
+* Add [`PERSONAL_DATA_DISCLOSURE.md`](PERSONAL_DATA_DISCLOSURE.md) file. Fixes UILDP-6.
 * Fixes for WCAG 2.1 accessibility. As described in detail in the Jira issue, it is not possible to achieve full compliance at this time due to extensive issues in Stripes itself, but I believe that when those are fixed this app will be clean. Fixes UILDP-5.
 * `yarn test` now runs from yakbak tapes, which can be regenerated using `yarn regenerate`. Fixes UILDP-11.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add [`PERSONAL_DATA_DISCLOSURE.md`](PERSONAL_DATA_DISCLOSURE.md) file. Fixes UILDP-6.
 * Fixes for WCAG 2.1 accessibility. As described in detail in the Jira issue, it is not possible to achieve full compliance at this time due to extensive issues in Stripes itself, but I believe that when those are fixed this app will be clean. Fixes UILDP-5.
 * `yarn test` now runs from yakbak tapes, which can be regenerated using `yarn regenerate`. Fixes UILDP-11.
+* The move from the `library-data-platform` GitHub area to `folio-org` is complete. The [`README.md`](README.md) file has been updated accordingly. Fixes UILDP-9.
 
 ## [1.4.0](https://github.com/folio-org/ui-ldp/tree/v1.4.0) (2021-09-27)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn start stripes.config.js
 [Library Data Platform](https://github.com/library-data-platform/ldp) (LDP)
 -- an open source platform for analytics in libraries.
 
-[mod-ldp](https://github.com/library-data-platform/mod-ldp)
+[mod-ldp](https://github.com/folio-org/mod-ldp)
 -- LDP query builder server-side module for FOLIO/ReShare.
 
 ### Code of Conduct
@@ -52,4 +52,7 @@ Refer to the Wiki [FOLIO Code of Conduct](https://wiki.folio.org/display/COMMUNI
 
 ### Issue tracker
 
-The project uses this GitHub [issue tracker](https://github.com/library-data-platform/ui-ldp/issues).
+This project intially used [its own GitHub issue tracker](https://github.com/folio-org/ui-ldp/issues).
+It is in the process of transitioning to [a JIRA tracker](https://issues.folio.org/projects/UILDP).
+For the present, issues may be found in both places.
+


### PR DESCRIPTION
The [`README.md`](../blob/master/README.md) file has been updated accordingly.

Fixes UILDP-9.
