### PR TITLE
Changing schema clears all fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Maintain query-form state when navigating away and returning. Fixes UILDP-10.
 * Add a Clear button that resets form state. Fixes UILDP-26.
+* Changing schema clears all fields, and they do not reappear when changing back. Fixes UILDP-25.
 
 ## [1.5.0](https://github.com/folio-org/ui-ldp/tree/v1.5.0) (2021-10-01)
 


### PR DESCRIPTION
And they do not reappear when changing back.

Fixes UILDP-25.