### PR TITLE
Ensure schema names from saved form state are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-ldp
 
+## [1.6.1](https://github.com/folio-org/ui-ldp/tree/v1.6.1) (IN PROGRESS)
+
+* If any schema-names loaded into the form from the previous session's state refer to schemas no longer supported by the back-end database, they are now changed to refer to a valid schema instead. Fixes UILDP-48.
+
 ## [1.6.0](https://github.com/folio-org/ui-ldp/tree/v1.6.0) (2022-03-02)
 
 * Maintain query-form state when navigating away and returning. Fixes UILDP-10.

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -22,6 +22,20 @@ function stateMayHaveChanged(stateHasChanged, values) {
 }
 
 
+// It can happen that the schema names that were stored as parts of
+// the form state in the previous session refer to schemas that are no
+// longer available in the underlying database (UILDP-48). When this
+// happens, we change them to refer to the first legitimate schema.
+//
+function ensureSchemasAreAvailable(initialState, schemaNames) {
+  initialState.tables.forEach(t => {
+    if (!schemaNames.includes(t.schema)) {
+      t.schema = schemaNames[0];
+    }
+  });
+}
+
+
 function QueryBuilder({ ldp, initialState, stateHasChanged, onClear, tables, setError }) {
   const intl = useIntl();
   const stripes = useStripes();
@@ -29,6 +43,8 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, onClear, tables, set
   const [showSaveModal, setShowSaveModal] = useState(false);
   const showDevInfo = stripes.config?.showDevInfo;
   const onSubmit = values => loadResults(intl, stripes, values, setQueryResponse, setError);
+
+  ensureSchemasAreAvailable(initialState, Object.keys(tables));
 
   return (
     <Paneset>


### PR DESCRIPTION
If any schema-names loaded into the form from the previous session's
state refer to schemas no longer supported by the back-end database,
they are now changed to refer to a valid schema instead.

Fixes UILDP-48.