### PR TITLE
Save query: filename is auto-generated from the display-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * If any schema-names loaded into the form from the previous session's state refer to schemas no longer supported by the back-end database, they are now changed to refer to a valid schema instead. Fixes UILDP-48.
 * Complete revamp of permissions. Fixes UILDP-47.
+* When saving a new query, the filename is auto-generated from the display-name. Fixes UILDP-46.
 
 ## [1.6.0](https://github.com/folio-org/ui-ldp/tree/v1.6.0) (2022-03-02)
 

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -121,11 +121,14 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, onClear, tables, set
                   </div>
                 </div>
               </div>
-              <SaveQueryModal
-                open={showSaveModal}
-                onClose={() => setShowSaveModal(false)}
-                queryFormValues={queryFormValues}
-              />
+              {
+                showSaveModal &&
+                  <SaveQueryModal
+                    onClose={() => setShowSaveModal(false)}
+                    queryFormValues={queryFormValues}
+                    autoUpdateName
+                  />
+              }
             </form>
           );
         }}

--- a/src/components/QueryBuilder/SaveQueryModal.js
+++ b/src/components/QueryBuilder/SaveQueryModal.js
@@ -8,11 +8,12 @@ import gitHubFetch from '../../util/gitHubFetch';
 import BigError from '../BigError';
 
 
-function SaveQueryModal({ open, onClose, queryFormValues }) {
+function SaveQueryModal({ onClose, queryFormValues, autoUpdateName }) {
   const callout = useContext(CalloutContext);
   const stripes = useStripes();
   const [config, setConfig] = useState();
   const [error, setError] = useState();
+  const [updateName, setUpdateName] = useState(autoUpdateName);
 
   useEffect(() => {
     fetchSavedQueryConfig(stripes, setConfig, setError);
@@ -97,7 +98,7 @@ function SaveQueryModal({ open, onClose, queryFormValues }) {
   return (
     <Modal
       id="save-query-modal"
-      open={open}
+      open
       onClose={onClose}
       dismissible
       label={<FormattedMessage id="ui-ldp.save-query" />}
@@ -106,14 +107,30 @@ function SaveQueryModal({ open, onClose, queryFormValues }) {
       <Row>
         <Col xs={4}>
           <TextField
+            id="save-query-modal-name"
             label={<FormattedMessage id="ui-ldp.saved-queries.name" />}
-            onChange={e => setValues({ ...values, name: e.target.value })}
+            onChange={
+              e => {
+                setUpdateName(false);
+                setValues({ ...values, name: e.target.value });
+              }
+            }
+            value={values.name}
           />
         </Col>
         <Col xs={8}>
           <TextField
             label={<FormattedMessage id="ui-ldp.saved-queries.displayName" />}
-            onChange={e => setValues({ ...values, displayName: e.target.value })}
+            onChange={
+              e => {
+                const newValues = { ...values, displayName: e.target.value };
+                if (updateName) {
+                  newValues.name = e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+                }
+                setValues(newValues);
+              }
+            }
+            autoFocus
           />
         </Col>
       </Row>
@@ -156,7 +173,6 @@ function SaveQueryModal({ open, onClose, queryFormValues }) {
 
 
 SaveQueryModal.propTypes = {
-  open: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   queryFormValues: PropTypes.shape({
     tables: PropTypes.arrayOf(
@@ -166,6 +182,7 @@ SaveQueryModal.propTypes = {
       }).isRequired,
     ).isRequired
   }).isRequired,
+  autoUpdateName: PropTypes.bool.isRequired,
 };
 
 


### PR DESCRIPTION
When the save-query modal popus up, the display-name field is
autofocused. As the user types into it, it is copied into the filename
field, with all letters downcased and all non-alphanumerics replaced
by underscored.

Once the user manually edits the filename, the copying no longer
happens. So you can type a display-name, get an autogenerated
filename, tweak that filename to your preference, then change the
display-name wihtout losing your filename changes.

Fixes UILDP-46.