### PR TITLE
Fake read-only status for GitHub token

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "displayName": "ui-ldp.meta.title",
     "route": "/ldp",
     "okapiInterfaces": {
-      "ldp-query": "1.0"
+      "ldp-query": "1.1"
     },
     "icons": [
       {

--- a/src/settings/SavedQueriesConfig.js
+++ b/src/settings/SavedQueriesConfig.js
@@ -13,7 +13,7 @@ function SavedQueriesConfig(props) {
         { name: 'owner', xs: 4 },
         { name: 'repo', xs: 4 },
         { name: 'branch', xs: 4 },
-        { name: 'token', xs: 12, placeholder: intl.formatMessage({ id: 'ui-ldp.placeholder.hidden' }) },
+        { name: 'token', xs: 12, fakeReadOnly: true, placeholder: intl.formatMessage({ id: 'ui-ldp.placeholder.hidden' }) },
       ]}
     />
   );

--- a/src/settings/components/LdpConfig.js
+++ b/src/settings/components/LdpConfig.js
@@ -98,7 +98,7 @@ function LdpConfig({ label, configKey: key, fields }) {
             <Col key={j} xs={field.xs}>
               <TextField
                 label={<FormattedMessage id={`ui-ldp.settings.${key}.${field.name}`} />}
-                value={currentConfig[field.name]}
+                value={field.fakeReadOnly ? '' : currentConfig[field.name]}
                 onChange={e => setCurrentConfig({ ...currentConfig, [field.name]: e.target.value })}
                 placeholder={field.placeholder}
               />


### PR DESCRIPTION
This allows us to avoid displaying the GitHub token that mod-ldp has
stored and returned to us, while still allowing it to be edited. To
the user, the result is as with the DB Config page's password, but
unlike that password we do need the server to actually give the client
the GitHub token, otherwise we can't use saved searches.