### PR TITLE
`core-js` no longer listed as a dependency at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.10.0 (IN PROGRESS)
 
-* `core-js` promoted from peer-dependency to full dependency. Fixes UILDP-66.
+* `core-js` no longer listed as a dependency. Fixes UILDP-66.
 
 ## [1.9.0](https://github.com/folio-org/ui-ldp/tree/v1.9.0) (2022-10-24)
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   },
   "dependencies": {
     "chart.js": "^2.9.3",
-    "core-js": "^3.6.1",
     "cross-fetch": "^3.0.6",
     "final-form": "^4.20.1",
     "final-form-arrays": "^3.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
 import React, { useState, useEffect } from 'react';


### PR DESCRIPTION
See discussion in UILDP-66.