### PR TITLE
"Table availability" list  is now sorted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0 (IN PROGRESS)
 
 * `core-js` no longer listed as a dependency. Fixes UILDP-66.
+* List of tables in "Table availability" settings page is now sorted correctly. Fixes UILDP-80
 
 ## [1.9.0](https://github.com/folio-org/ui-ldp/tree/v1.9.0) (2022-10-24)
 

--- a/src/settings/TableAvailability.js
+++ b/src/settings/TableAvailability.js
@@ -80,7 +80,7 @@ function TableAvailability(props) {
             <ul style={{ listStyleType: 'none' }}>
               {
                 tables[key]
-                  .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? -1 : 0))
+                  .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0))
                   .map(entry => (
                     <li key={entry.value}>
                       <Field


### PR DESCRIPTION
Fixes UILDP-80