### PR TITLE
Record export limit now applies to large sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Remove all traces of the old `sqconfig` (permissions, settings pages, etc.)
 * Handle disappearing queries more gracefully. Fixes UILDP-88.
 * Saved queries: maintain username/date for both created and updated events. Fixes UILDP-87.
+* Record export limit now applies to sets larger than mod-ldp's default of 500. Fixes UILDP-68.
 
 ## [1.9.0](https://github.com/folio-org/ui-ldp/tree/v1.9.0) (2022-10-24)
 

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -46,7 +46,7 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
   const [alreadyExecuted, setAlreadyExecuted] = useState(false);
   const showDevInfo = stripes.config?.showDevInfo;
   const onSubmit = values => loadResults(intl, stripes, values, setQueryResponse, setError);
-  const searchWithoutLimit = setResponse => loadResults(intl, stripes, _savedValues, setResponse, setError, true);
+  const searchWithoutLimit = setResponse => loadResults(intl, stripes, _savedValues, setResponse, setError, ldp.maxExport);
 
   ensureSchemasAreAvailable(initialState, Object.keys(tables));
   if (execute && !alreadyExecuted) {

--- a/src/util/loadResults.js
+++ b/src/util/loadResults.js
@@ -2,12 +2,12 @@ import cloneDeep from 'lodash.clonedeep';
 import { v4 as uuidv4 } from 'uuid';
 import loadData from './loadData';
 
-const loadResults = async (intl, stripes, values, setQueryResponse, setError, ignoreLimit) => {
-  const limit = values.tables[0].limit;
+const loadResults = async (intl, stripes, values, setQueryResponse, setError, limit) => {
+  if (limit === undefined) limit = values.tables[0].limit;
 
   function setData(raw) {
     raw.forEach(v => { delete v.data; });
-    const isComplete = ignoreLimit || raw.length < limit;
+    const isComplete = raw.length < limit;
 
     if (!isComplete) {
       let firstField;
@@ -24,7 +24,7 @@ const loadResults = async (intl, stripes, values, setQueryResponse, setError, ig
 
     setQueryResponse({
       key: uuidv4(),
-      count: isComplete || ignoreLimit ? raw.length : limit,
+      count: isComplete ? raw.length : limit,
       isComplete,
       resp: raw,
     });
@@ -32,12 +32,8 @@ const loadResults = async (intl, stripes, values, setQueryResponse, setError, ig
 
   const modifiedValues = cloneDeep(values);
   delete modifiedValues.META;
-  if (ignoreLimit) {
-    modifiedValues.tables[0].limit = undefined;
-  } else {
-    // Send a limit value one greater than what the user specified
-    modifiedValues.tables[0].limit = parseInt(limit, 10) + 1;
-  }
+  // Send a limit value one greater than what the user specified
+  modifiedValues.tables[0].limit = parseInt(limit, 10) + 1;
 
   loadData(intl, stripes, 'results', '/ldp/db/query', setData, setError, {
     method: 'POST',


### PR DESCRIPTION
Previously, large sets were limited to mod-ldp's default of 500.

Fixes UILDP-68.