### PR TITLE
Upgrade from Stripes v7 to Stripes v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0 (IN PROGRESS)
 
+* Upgrade from Stripes v7 to Stripes v8 (though should still work with v7). Fixes UILDP-79.
 * `core-js` no longer listed as a dependency. Fixes UILDP-66.
 * List of tables in "Table availability" settings page is now sorted correctly. Fixes UILDP-80
 * Update Record Limits/Table Availability to use mod-settings. Fixes UILDP-81.

--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "@calm/eslint-plugin-react-intl": "^1.4.1",
     "@cypress/code-coverage": "^3.9.6",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@folio/stripes": "^6.0.0 || ^7.0.0",
-    "@folio/stripes-cli": "~2.5.0",
+    "@folio/stripes": "^8.0.0",
+    "@folio/stripes-cli": "^2.7.0",
     "@testing-library/jest-dom": "^5.11.1",
     "@testing-library/react": "^11.0.2",
     "@testing-library/user-event": "^12.1.10",
     "babel-jest": "^26.3.0",
     "babel-plugin-require-context-hook": "^1.0.0",
     "chai": "^4.2.0",
-    "cypress": "^7.4.0",
+    "cypress": "^6.4.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-cypress": "^2.11.3",
@@ -83,7 +83,7 @@
     "uuid": "^8.3.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^6.0.0 || ^7.0.0",
+    "@folio/stripes": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "react": "^16.0.0 || ^17.0.2",
     "react-intl": "^5.8.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
(Though this should still work with v6 and v7).

For subtle reasons, to with `rxjs` versions, to get this to work it was necessary to downgrade Cypress from `^7.4.0` to `^6.4.0`. This will do for now, but as Cypress has leapt ahead five more major versions to v12.5.1 at the time of writing, we will clearly need to revisit this.

Fixes UILDP-79.