### PR TITLE
Create dynamic tabs for selected Templated Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Rip out old redundant copy of stripes-smart-components/ConfigManager. Fixes UILDP-101.
 * Settings page for maintaining set of GitHub repos containing Templated Queries. Fixes UILDP-97.
 * New "Templates" tab that lists available Templated Queries. Fixes UILDP-98.
+* Create dynamic tabs for selected Templated Queries. Fixes UILDP-99.
 
 ## [1.10.1](https://github.com/folio-org/ui-ldp/tree/v1.10.1) (2023-07-28)
 

--- a/src/components/TemplatedQueries/TemplatedQueries.js
+++ b/src/components/TemplatedQueries/TemplatedQueries.js
@@ -1,10 +1,22 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
-import { Paneset, Pane, MultiColumnList, NoValue } from '@folio/stripes/components';
+import { Paneset, Pane, MultiColumnList } from '@folio/stripes/components';
+import { useLdp } from '../../LdpContext';
+import templatedQueryName from '../../util/templatedQueryName';
+
 
 function TemplatedQueries({ queries }) {
-  const [query, setQuery] = useState();
+  const history = useHistory();
+  const ldp = useLdp();
+
+  function navigateToQuery(q) {
+    const qname = templatedQueryName(q);
+    const existing = ldp.tqTabs.filter(tab => tab.name === qname);
+    if (existing.length === 0) ldp.tqTabs.push({ ...q, name: qname });
+    history.push(`/ldp/tq/${qname}`);
+  }
 
   return (
     <Paneset>
@@ -23,18 +35,13 @@ function TemplatedQueries({ queries }) {
             displayName: r => r.json?.displayName,
             repo: r => `${r.config.user}/${r.config.repo}`,
           }}
-          onRowClick={(_, q) => setQuery(q)}
+          onRowClick={(_, q) => navigateToQuery(q)}
         />
       </Pane>
-      {query &&
-        <Pane defaultWidth="50%" paneTitle="Fill in query parameters">
-          <NoValue />
-          <pre>{JSON.stringify(query, null, 2)}</pre>
-        </Pane>
-      }
     </Paneset>
   );
 }
+
 
 TemplatedQueries.propTypes = {
   queries: PropTypes.arrayOf(
@@ -51,5 +58,6 @@ TemplatedQueries.propTypes = {
     }).isRequired,
   ),
 };
+
 
 export default TemplatedQueries;

--- a/src/components/TemplatedQuery/TemplatedQuery.js
+++ b/src/components/TemplatedQuery/TemplatedQuery.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Pane } from '@folio/stripes/components';
+
+function TemplatedQuery({ query }) {
+  const title = query.json?.displayName || query.name;
+  return (
+    <Pane defaultWidth="fill" paneTitle={title}>
+      <pre>{JSON.stringify(query, null, 2)}</pre>
+    </Pane>
+  );
+}
+
+TemplatedQuery.propTypes = {
+  query: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    json: PropTypes.shape({
+      displayName: PropTypes.string,
+    }),
+  }).isRequired,
+};
+
+export default TemplatedQuery;

--- a/src/components/TemplatedQuery/index.js
+++ b/src/components/TemplatedQuery/index.js
@@ -1,0 +1,1 @@
+export { default } from './TemplatedQuery';

--- a/src/routes/TemplatedQueryRoute.js
+++ b/src/routes/TemplatedQueryRoute.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+import { useLdp } from '../LdpContext';
+import BigError from '../components/BigError';
+import TemplatedQuery from '../components/TemplatedQuery';
+
+function TemplatedQueryRoute() {
+  const intl = useIntl();
+  const location = useLocation();
+  const ldp = useLdp();
+
+  const qname = location.pathname.replace('/ldp/tq/', '');
+  const matching = ldp.tqTabs?.filter(tab => tab.name === qname);
+  if (!matching || matching.length === 0) {
+    const error = intl.formatMessage(
+      { id: 'ui-ldp.error.no-such-query' },
+      { qname }
+    );
+    return <BigError message={error} />;
+  }
+
+  return <TemplatedQuery query={matching[0]} />;
+}
+
+export default TemplatedQueryRoute;

--- a/src/util/defaultConfig.js
+++ b/src/util/defaultConfig.js
@@ -6,6 +6,9 @@ const defaultConfig = {
 
   // Managed in ../settings/TableAvailability.js
   disabledTables: [],
+
+  // Managed in ../components/TemplatedQueries/TemplatedQueries.js
+  tqTabs: [],
 };
 
 export default defaultConfig;

--- a/src/util/templatedQueryName.js
+++ b/src/util/templatedQueryName.js
@@ -1,0 +1,5 @@
+const baseName = filename => filename.replace(/(.*)\..*/, '$1');
+
+export default function templatedQueryName(q) {
+  return `${q.config.user}/${q.config.repo}/${q.config.branch}/${q.config.dir}/${baseName(q.filename)}`;
+}

--- a/translations/ui-ldp/en.json
+++ b/translations/ui-ldp/en.json
@@ -10,6 +10,7 @@
   "error.load-columns": "Could not load columns: {error}",
   "error.load-results": "Could not load results: {error}",
   "error.load-queries": "Could not load saved queries: {error}",
+  "error.no-such-query": "No such templated query: {qname}",
   "nav": "Navigation",
   "nav.query-builder": "Query builder",
   "nav.saved-queries": "Saved queries",


### PR DESCRIPTION
At this point, the tabs only show a JSON rendering of the query and associated metdata. We'll address that in UILDP-104.

Fixes UILDP-99.