### PR TITLE
Permissions fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * New "Templates" tab that lists available Templated Queries. Fixes UILDP-98.
 * Create dynamic tabs for selected Templated Queries. Fixes UILDP-99.
 * Update Node.js to v18 in GitHub Actions. Fixes UILDP-106.
+* `module.ldp.enabled` and `settings.ldp.enabled` permissionss are no longer visible, in accordance with standard practice in FOLIO. Fixes UILDP-95.
+* All appropriate LDP permissions are now correctly included as subpermissions of `ui-ldp.all`. Fixes UILDP-108.
 
 ## [1.10.1](https://github.com/folio-org/ui-ldp/tree/v1.10.1) (2023-07-28)
 

--- a/package.json
+++ b/package.json
@@ -110,16 +110,15 @@
           "mod-settings.global.read.ui-ldp.admin",
           "mod-settings.global.read.ui-ldp.queries"
         ],
-        "visible": true
+        "visible": false
       },
       {
         "permissionName": "settings.ldp.enabled",
         "displayName": "Settings (LDP): Can view settings",
         "subPermissions": [
-          "settings.enabled",
-          "mod-settings.global.read.ui-ldp.admin"
+          "settings.enabled"
         ],
-        "visible": true
+        "visible": false
       },
       {
         "permissionName": "ui-ldp.settings.record-limits",
@@ -173,7 +172,8 @@
           "ui-ldp.settings.record-limits",
           "ui-ldp.settings.table-availability",
           "ui-ldp.settings.dbinfo",
-          "ui-ldp.settings.tqrepos"
+          "ui-ldp.settings.tqrepos",
+          "mod-settings.global.write.ui-ldp.queries"
         ],
         "visible": true
       },


### PR DESCRIPTION
* `module.ldp.enabled` and `settings.ldp.enabled` permissionss are no longer visible, in accordance with standard practice in FOLIO. Fixes UILDP-95.
* All appropriate LDP permissions are now correctly included as subpermissions of `ui-ldp.all`. Fixes UILDP-108.