### PR TITLE
Limit number of records retrieved for reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UILDP-109.
 * Handle form generation and filling for templated queries. Fixes UILDP-105.
 * Show results of running templated query. Fixes UILDP-100.
+* Number of records retrieved for templated queries is limited according to configured parameters. Fixes UILDP-112.
 
 ## [1.10.1](https://github.com/folio-org/ui-ldp/tree/v1.10.1) (2023-07-28)
 

--- a/src/components/TemplatedQuery/TemplatedQuery.js
+++ b/src/components/TemplatedQuery/TemplatedQuery.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useStripes } from '@folio/stripes/core';
 import { Pane, Accordion } from '@folio/stripes/components';
+import { useLdp } from '../../LdpContext';
 import loadReport from '../../util/loadReport';
 import BigError from '../BigError';
 import ResultsList from '../QueryBuilder/ResultsList';
@@ -14,12 +15,13 @@ function TemplatedQuery({ query }) {
   const [error, setError] = useState();
   const intl = useIntl();
   const stripes = useStripes();
+  const ldp = useLdp();
   const title = query.json?.displayName || query.name;
 
   const onSubmit = async (values) => {
     const qc = query.config;
     const url = `https://raw.githubusercontent.com/${qc.user}/${qc.repo}/${qc.branch}/${qc.dir}/${query.filename}`;
-    const limit = 5; // XXX
+    const limit = ldp.maxShow;
     loadReport(intl, stripes, url, values, setData, setError, limit);
   };
 

--- a/src/components/TemplatedQuery/TemplatedQuery.js
+++ b/src/components/TemplatedQuery/TemplatedQuery.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useStripes } from '@folio/stripes/core';
 import { Pane, Accordion } from '@folio/stripes/components';
-import loadData from '../../util/loadData';
+import loadReport from '../../util/loadReport';
 import BigError from '../BigError';
 import ResultsList from '../QueryBuilder/ResultsList';
 import TemplatedQueryForm from './TemplatedQueryForm';
@@ -19,14 +19,8 @@ function TemplatedQuery({ query }) {
   const onSubmit = async (values) => {
     const qc = query.config;
     const url = `https://raw.githubusercontent.com/${qc.user}/${qc.repo}/${qc.branch}/${qc.dir}/${query.filename}`;
-    loadData(intl, stripes, 'report', '/ldp/db/reports', setData, setError, {
-      method: 'POST',
-      body: JSON.stringify({
-        url,
-        // limit: XXX,
-        params: values,
-      }),
-    });
+    const limit = 5; // XXX
+    loadReport(intl, stripes, url, values, setData, setError, limit);
   };
 
   if (error) return <BigError message={error} />;
@@ -34,7 +28,7 @@ function TemplatedQuery({ query }) {
   return (
     <Pane defaultWidth="fill" paneTitle={title} dismissible={!!data} onClose={() => setData()}>
       {data ? (
-        <ResultsList results={{ key: 'report-results', resp: data.records }} />
+        <ResultsList results={data} />
       ) : (
         <>
           {!query.json ? (

--- a/src/util/loadReport.js
+++ b/src/util/loadReport.js
@@ -1,0 +1,33 @@
+import { v4 as uuidv4 } from 'uuid';
+import loadData from './loadData';
+
+const loadReport = async (intl, stripes, url, params, setQueryResponse, setError, limit) => {
+  function setData(raw) {
+    const isComplete = raw.totalRecords < limit;
+
+    if (!isComplete) {
+      let firstField;
+
+      // ### I don't know if this is guaranteed to work, but it seems to
+      Object.keys(raw.records[0]).forEach(key => {
+        if (!firstField) firstField = key;
+      });
+
+      raw.records.push({ [firstField]: '... More records ...' });
+    }
+
+    setQueryResponse({
+      key: uuidv4(),
+      count: raw.totalRecords,
+      isComplete,
+      resp: raw.records,
+    });
+  }
+
+  loadData(intl, stripes, 'report', '/ldp/db/reports', setData, setError, {
+    method: 'POST',
+    body: JSON.stringify({ url, params, limit }),
+  });
+};
+
+export default loadReport;


### PR DESCRIPTION
The number of records retrieved for templated queries is limited according to the configured `maxShow` parameter.

Fixes UILDP-112.