### PR TITLE
Query-builder results pop up over query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Make internal permissions used by mod-settings invisible. Fixes UILDP-127.
 * Report metadata files can specify default values for report parameters. Fixes UILDP-124.
 * Report metadata files can specify that report parameters are disabled. Fixes UILDP-125.
+* Results from query-builder appear in place of, rather than below, the query for. Fixes UILDP-118, though we will revisit this UX in a future release.
 
 ## [2.0.0](https://github.com/folio-org/ui-ldp/tree/v2.0.0) (2023-09-30)
 

--- a/src/components/QueryBuilder/QueryBuilder.css
+++ b/src/components/QueryBuilder/QueryBuilder.css
@@ -5,7 +5,7 @@
   padding-bottom: 4px;
 }
 
-.SubmitRow {
+.ResultsSummary {
   display: flex;
   justify-content: space-between;
   font-size: 1.2em;

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -141,11 +141,9 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
                             namePrefix={namePrefix}
                             tableIndex={tableIndex}
                             tables={tables}
-                            queryResponse={queryResponse}
                             onRemove={() => fields.remove(tableIndex)}
                             push={push}
                             pop={pop}
-                            searchWithoutLimit={searchWithoutLimit}
                           />
                         </Pane>
                       ))}
@@ -162,7 +160,7 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
                 </div>
                 <div style={{ height: '100%' }}>
                   <div style={{ height: '100%' }}>
-                    <ResultsList results={queryResponse} />
+                    <ResultsList results={queryResponse} searchWithoutLimit={searchWithoutLimit} />
                   </div>
                 </div>
               </div>

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -74,6 +74,15 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
     setShowCopyModal(false);
   };
 
+  if (queryResponse) {
+    const title = initialState.META?.displayName;
+    return (
+      <Pane defaultWidth="fill" paneTitle={title} dismissible onClose={() => setQueryResponse()}>
+        <ResultsList results={queryResponse} searchWithoutLimit={searchWithoutLimit} />
+      </Pane>
+    );
+  }
+
   return (
     <Paneset>
       <FinalForm
@@ -157,11 +166,6 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
                       </Pane>
                     }
                   </Paneset>
-                </div>
-                <div style={{ height: '100%' }}>
-                  <div style={{ height: '100%' }}>
-                    <ResultsList results={queryResponse} searchWithoutLimit={searchWithoutLimit} />
-                  </div>
                 </div>
               </div>
               <ConfirmationModal

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -39,7 +39,7 @@ function ensureSchemasAreAvailable(initialState, schemaNames) {
 function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, onClear, tables, setError, execute }) {
   const intl = useIntl();
   const stripes = useStripes();
-  const [queryResponse, setQueryResponse] = useState({ key: null, resp: [] });
+  const [queryResponse, setQueryResponse] = useState();
   const [showNewModal, setShowNewModal] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [showCopyModal, setShowCopyModal] = useState(false);

--- a/src/components/QueryBuilder/QuerySingleTable.js
+++ b/src/components/QueryBuilder/QuerySingleTable.js
@@ -7,14 +7,13 @@ import { FieldArray } from 'react-final-form-arrays';
 import { OnChange } from 'react-final-form-listeners';
 import { useStripes } from '@folio/stripes/core';
 import { Button, Label, MultiSelection, OptionSegment, Select, Selection } from '@folio/stripes/components';
-import { exportCsv } from '@folio/stripes/util';
 import { useLdp } from '../../LdpContext';
 import loadColumns from '../../util/loadColumns';
 import generateOptions from '../../util/generateOptions';
 import BigError from '../BigError';
 import ColumnFilter from './ColumnFilter';
 import OrderingCriterion from './OrderingCriterion';
-import css from './QuerySingleTable.css';
+import css from './QueryBuilder.css';
 
 
 const WhenFieldChanges = ({ field, set, to }) => (
@@ -73,10 +72,8 @@ const QuerySingleTable = ({
   namePrefix,
   tableIndex,
   tables,
-  queryResponse,
   // onRemove,
   push,
-  searchWithoutLimit,
 }) => {
   const intl = useIntl();
   const stripes = useStripes();
@@ -95,14 +92,6 @@ const QuerySingleTable = ({
   if (error) return <BigError message={error} />;
 
   const disabled = !selectedTableName;
-
-  const maybeExportCsv = (qr) => {
-    if (qr.isComplete) {
-      exportCsv(qr.resp, {});
-    } else {
-      searchWithoutLimit(r => exportCsv(r.resp, {}));
-    }
-  };
 
   return (
     <div className={css.QuerySingleTable} data-test-table>
@@ -219,34 +208,14 @@ const QuerySingleTable = ({
           disabled={disabled}
         />
 
-        <div className={css.SubmitRow}>
-          <span>
-            <Button
-              type="submit"
-              buttonStyle="primary"
-              disabled={disabled}
-              data-cy={`${namePrefix}.submit`}
-            >
-              <FormattedMessage id="ui-ldp.button.submit" />
-            </Button>
-          </span>
-          <span data-cy={`${namePrefix}.message`}>
-            {queryResponse.key && (
-              queryResponse.isComplete ?
-                <FormattedMessage id="ui-ldp.found-records" values={{ count: queryResponse.count }} /> :
-                <FormattedMessage id="ui-ldp.found-more-than" values={{ count: queryResponse.count }} />
-            )}
-          </span>
-          <Button
-            aria-label={intl.formatMessage({ id: 'ui-ldp.button.download-csv' })}
-            disabled={!get(queryResponse, 'resp.length')}
-            onClick={() => maybeExportCsv(queryResponse)}
-            xstyle={{ marginTop: '-1em' }}
-            data-cy={`${namePrefix}.downloadCSV`}
-          >
-            <FormattedMessage id="ui-ldp.button.csv" />
-          </Button>
-        </div>
+        <Button
+          type="submit"
+          buttonStyle="primary"
+          disabled={disabled}
+          data-cy={`${namePrefix}.submit`}
+        >
+          <FormattedMessage id="ui-ldp.button.submit" />
+        </Button>
       </div>
     </div>
   );
@@ -256,10 +225,8 @@ QuerySingleTable.propTypes = {
   namePrefix: PropTypes.string,
   tableIndex: PropTypes.number,
   tables: PropTypes.object,
-  queryResponse: PropTypes.object,
   push: PropTypes.func,
   // pop: PropTypes.func,
-  searchWithoutLimit: PropTypes.func.isRequired,
 };
 
 

--- a/src/components/QueryBuilder/ResultsList.js
+++ b/src/components/QueryBuilder/ResultsList.js
@@ -14,7 +14,7 @@ const NULLValue = <span style={{ color: 'grey' }}>[NULL]</span>;
 const ResultsList = ({ results, searchWithoutLimit }) => {
   const intl = useIntl();
 
-  if (!results.key) return null;
+  if (!results) return null;
 
   const data = results.resp || [];
   const formatter = {};
@@ -36,15 +36,14 @@ const ResultsList = ({ results, searchWithoutLimit }) => {
     <>
       <div className={css.ResultsSummary}>
         <span data-cy="results.message">
-          {results.key && (
-            results.isComplete ?
-              <FormattedMessage id="ui-ldp.found-records" values={{ count: results.count }} /> :
-              <FormattedMessage id="ui-ldp.found-more-than" values={{ count: results.count }} />
-          )}
+          {results.isComplete ?
+            <FormattedMessage id="ui-ldp.found-records" values={{ count: results.count }} /> :
+            <FormattedMessage id="ui-ldp.found-more-than" values={{ count: results.count }} />
+          }
         </span>
         <Button
           aria-label={intl.formatMessage({ id: 'ui-ldp.button.download-csv' })}
-          disabled={!results.resp?.length}
+          disabled={!data.length}
           onClick={() => maybeExportCsv(results)}
           xstyle={{ marginTop: '-1em' }}
           data-cy="results.downloadCSV"
@@ -52,7 +51,7 @@ const ResultsList = ({ results, searchWithoutLimit }) => {
           <FormattedMessage id="ui-ldp.button.csv" />
         </Button>
       </div>
-      <MultiColumnList key={results.key} contentData={data} formatter={formatter} virtualize autosize />
+      <MultiColumnList contentData={data} formatter={formatter} virtualize autosize />
     </>
   );
 };

--- a/src/components/QueryBuilder/ResultsList.js
+++ b/src/components/QueryBuilder/ResultsList.js
@@ -1,12 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MultiColumnList } from '@folio/stripes/components';
+import { useIntl, FormattedMessage } from 'react-intl';
+import { exportCsv } from '@folio/stripes/util';
+import { Button, MultiColumnList } from '@folio/stripes/components';
+import css from './QueryBuilder.css';
+
 
 // NULL is NULL all over the world, and does not need localizing
 // eslint-disable-next-line @calm/react-intl/missing-formatted-message
 const NULLValue = <span style={{ color: 'grey' }}>[NULL]</span>;
 
-const ResultsList = ({ results }) => {
+
+const ResultsList = ({ results, searchWithoutLimit }) => {
+  const intl = useIntl();
+
   if (!results.key) return null;
 
   const data = results.resp || [];
@@ -17,11 +24,44 @@ const ResultsList = ({ results }) => {
     });
   }
 
-  return <MultiColumnList key={results.key} contentData={data} formatter={formatter} virtualize autosize />;
+  const maybeExportCsv = (qr) => {
+    if (qr.isComplete) {
+      exportCsv(qr.resp, {});
+    } else {
+      searchWithoutLimit(r => exportCsv(r.resp, {}));
+    }
+  };
+
+  return (
+    <>
+      <div className={css.ResultsSummary}>
+        <span data-cy="results.message">
+          {results.key && (
+            results.isComplete ?
+              <FormattedMessage id="ui-ldp.found-records" values={{ count: results.count }} /> :
+              <FormattedMessage id="ui-ldp.found-more-than" values={{ count: results.count }} />
+          )}
+        </span>
+        <Button
+          aria-label={intl.formatMessage({ id: 'ui-ldp.button.download-csv' })}
+          disabled={!results.resp?.length}
+          onClick={() => maybeExportCsv(results)}
+          xstyle={{ marginTop: '-1em' }}
+          data-cy="results.downloadCSV"
+        >
+          <FormattedMessage id="ui-ldp.button.csv" />
+        </Button>
+      </div>
+      <MultiColumnList key={results.key} contentData={data} formatter={formatter} virtualize autosize />
+    </>
+  );
 };
+
 
 ResultsList.propTypes = {
   results: PropTypes.object,
+  searchWithoutLimit: PropTypes.func.isRequired,
 };
+
 
 export default ResultsList;


### PR DESCRIPTION
Results from query-builder appear in place of, rather than below, the query for.

Fixes UILDP-118, though we will revisit this UX in a future release.