### PR TITLE
Closing results no longer resets query to last loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Report metadata files can specify that report parameters are disabled. Fixes UILDP-125.
 * Results from query-builder appear in place of, rather than below, the query for. Fixes UILDP-118, though we will revisit this UX in a future release.
 * When adding the initial report repository', `+` no longer creates two empty templates. Fixes UILDP-126.
+* Submitting a query from the builder, then closing the results, no longer resets to the last loaded query. Fixes UILDP-130.
 
 ## [2.0.0](https://github.com/folio-org/ui-ldp/tree/v2.0.0) (2023-09-30)
 

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -74,14 +74,6 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
     setShowCopyModal(false);
   };
 
-  if (queryResponse) {
-    const title = initialState.META?.displayName;
-    return (
-      <Pane defaultWidth="fill" paneTitle={title} dismissible onClose={() => setQueryResponse()}>
-        <ResultsList results={queryResponse} searchWithoutLimit={searchWithoutLimit} />
-      </Pane>
-    );
-  }
 
   return (
     <Paneset>
@@ -98,6 +90,15 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
             mutators: { push, pop }
           }
         }) => {
+          if (queryResponse) {
+            const title = initialState.META?.displayName;
+            return (
+              <Pane defaultWidth="fill" paneTitle={title} dismissible onClose={() => setQueryResponse()}>
+                <ResultsList results={queryResponse} searchWithoutLimit={searchWithoutLimit} />
+              </Pane>
+            );
+          }
+
           const queryFormValues = getState().values;
           // console.log('QueryBuilder: queryFormValues =', queryFormValues);
           stateMayHaveChanged(stateHasChanged, queryFormValues);

--- a/src/util/localforage-with-logging.js
+++ b/src/util/localforage-with-logging.js
@@ -1,0 +1,24 @@
+// Only needed for debugging
+
+import localforage from 'localforage';
+
+const localforageWithDebugging = {
+  setItem: async (namespace, value) => {
+    const res = await localforage.setItem(namespace, value);
+    // eslint-disable-next-line no-console
+    console.log(`localforage: set '${namespace}' to`, value);
+    return res;
+  },
+  getItem: async (namespace) => {
+    const value = await localforage.getItem(namespace);
+    // eslint-disable-next-line no-console
+    console.log(`localforage: get '${namespace}' yielded`, value);
+    return value;
+  },
+
+  // Full API also includes: removeItem, clear, length, key, keys, iterate
+  // But we don't use those in ui-ldp, so no need to proxy them
+  // See https://localforage.github.io/localForage/
+};
+
+export default localforageWithDebugging;


### PR DESCRIPTION
Submitting a query from the builder, then closing the results, no longer resets to the last loaded query.
    
I have _absolutely no idea_ why this fixes fixes this bug, but it does. And since I still have absolutely no idea how the bug happens in the first place, I guess it all balances out.
    
        ¯\_(ツ)_/¯
    
Fixes UILDP-130.
