### PR TITLE
Correctly read configuration from mod-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0](https://github.com/folio-org/ui-ldp/tree/v2.1.0) (2024-03-19)
 
 * Remove unnecessary `cross-fetch` dependency which may be interfering with new authentication regimen. Fixes UILDP-145.
+* Correctly read configuration (disabled tables and default result sizes) from mod-settings. Fixes UILDP-144.
 
 ## [2.0.1](https://github.com/folio-org/ui-ldp/tree/v2.0.1) (2023-11-16)
 

--- a/src/components/QueryBuilder/QueryBuilder.js
+++ b/src/components/QueryBuilder/QueryBuilder.js
@@ -171,7 +171,7 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
               </div>
               <ConfirmationModal
                 open={showNewModal}
-                heading={<FormattedMessage id="ui-ldp.button.new-query" />}
+                heading={intl.formatMessage({ id: 'ui-ldp.button.new-query' })}
                 message={<FormattedMessage id="ui-ldp.desc.new-query" />}
                 confirmLabel={<FormattedMessage id="ui-ldp.button.new-query" />}
                 onConfirm={newQuery}
@@ -187,7 +187,7 @@ function QueryBuilder({ ldp, initialState, stateHasChanged, metadataHasChanged, 
               }
               <ConfirmationModal
                 open={showCopyModal}
-                heading={<FormattedMessage id="ui-ldp.button.copy-query" />}
+                heading={intl.formatMessage({ id: 'ui-ldp.button.copy-query' })}
                 message={<FormattedMessage id="ui-ldp.desc.copy-query" />}
                 confirmLabel={<FormattedMessage id="ui-ldp.button.copy-query" />}
                 onConfirm={copyQuery}

--- a/src/util/loadConfig.js
+++ b/src/util/loadConfig.js
@@ -9,8 +9,8 @@ const loadConfig = async (intl, stripes, ldp, setConfigLoaded, setError) => {
 
   function setData(raw) {
     let data;
-    if (raw.configs && raw.configs.length !== 0) {
-      data = JSON.parse(raw.configs[0].value);
+    if (raw.items && raw.items.length !== 0) {
+      data = JSON.parse(raw.items[0].value);
     } else {
       data = defaultConfig;
     }


### PR DESCRIPTION
This includes the set of disabled tables and the default result sizes.

I messed this up when we switched from using mod-configuration to mod-settings. We were fetching from the correct path, but incorrectly still looking at the response data's `configs`. For mod-settings, it's `items`.

(While I was here, I patched around a picky console error, where `<ConfirmationModal>`'s propTypes incorrectly claim it needs a string for the `heading` prop, when in fact it's just fine with a rendered component.)

Fixes UILDP-144.