### PR TITLE
Templated query form retains entered values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Correctly read configuration (disabled tables and default result sizes) from mod-settings. Fixes UILDP-144.
 * **Temporarily** use a simple textbox instead of `<AutoSuggest>` in generated query forms. Addresses UILDP-147.
+* Closing the results list from a "Run report" query no longer clears entered parameters. Fixes UILDP-138.
 
 ## [2.1.0](https://github.com/folio-org/ui-ldp/tree/v2.1.0) (2024-03-19)
 

--- a/src/components/QueryBuilder/ResultsList.js
+++ b/src/components/QueryBuilder/ResultsList.js
@@ -58,7 +58,12 @@ const ResultsList = ({ results, searchWithoutLimit }) => {
 
 
 ResultsList.propTypes = {
-  results: PropTypes.object,
+  results: PropTypes.shape({
+    count: PropTypes.number.isRequired,
+    isComplete: PropTypes.bool.isRequired,
+    // eslint-disable-next-line react/forbid-prop-types
+    resp: PropTypes.array.isRequired,
+  }),
   searchWithoutLimit: PropTypes.func, // not .isRequired when called from TemplatedQuery.js
 };
 

--- a/src/components/TemplatedQuery/TemplatedQuery.js
+++ b/src/components/TemplatedQuery/TemplatedQuery.js
@@ -6,7 +6,6 @@ import { Pane, Accordion } from '@folio/stripes/components';
 import { useLdp } from '../../LdpContext';
 import loadReport from '../../util/loadReport';
 import BigError from '../BigError';
-import ResultsList from '../QueryBuilder/ResultsList';
 import TemplatedQueryForm from './TemplatedQueryForm';
 import css from './TemplatedQuery.css';
 
@@ -29,8 +28,6 @@ function TemplatedQuery({ query }) {
     <Pane defaultWidth="fill" paneTitle={title} dismissible={!!data} onClose={() => setData()}>
       {error ? (
         <BigError message={error} />
-      ) : data ? (
-        <ResultsList results={data} />
       ) : (
         <>
           {!query.json ? (
@@ -38,7 +35,7 @@ function TemplatedQuery({ query }) {
               <FormattedMessage id="ui-ldp.templated-queries.no-json" />
             </div>
           ) : (
-            <TemplatedQueryForm query={query} onSubmit={onSubmit} />
+            <TemplatedQueryForm query={query} onSubmit={onSubmit} data={data} />
           )}
           <br style={{ marginTop: '2em' }} />
           <Accordion closedByDefault label={<FormattedMessage id="ui-ldp.devinfo" />}>

--- a/src/components/TemplatedQuery/TemplatedQuery.js
+++ b/src/components/TemplatedQuery/TemplatedQuery.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useStripes } from '@folio/stripes/core';
-import { Pane, Accordion } from '@folio/stripes/components';
+import { Pane } from '@folio/stripes/components';
 import { useLdp } from '../../LdpContext';
 import loadReport from '../../util/loadReport';
 import BigError from '../BigError';
@@ -29,19 +29,13 @@ function TemplatedQuery({ query }) {
       {error ? (
         <BigError message={error} />
       ) : (
-        <>
-          {!query.json ? (
-            <div className={css.noJsonError}>
-              <FormattedMessage id="ui-ldp.templated-queries.no-json" />
-            </div>
-          ) : (
-            <TemplatedQueryForm query={query} onSubmit={onSubmit} data={data} />
-          )}
-          <br style={{ marginTop: '2em' }} />
-          <Accordion closedByDefault label={<FormattedMessage id="ui-ldp.devinfo" />}>
-            <pre>{JSON.stringify(query, null, 2)}</pre>
-          </Accordion>
-        </>
+        !query.json ? (
+          <div className={css.noJsonError}>
+            <FormattedMessage id="ui-ldp.templated-queries.no-json" />
+          </div>
+        ) : (
+          <TemplatedQueryForm query={query} onSubmit={onSubmit} data={data} />
+        )
       )}
     </Pane>
   );

--- a/src/components/TemplatedQuery/TemplatedQueryForm.js
+++ b/src/components/TemplatedQuery/TemplatedQueryForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Form, Field } from 'react-final-form';
-import { TextField, Datepicker, Select, /* AutoSuggest, */ Button } from '@folio/stripes/components';
+import { TextField, Datepicker, Select, /* AutoSuggest, */ Button, Accordion } from '@folio/stripes/components';
 import baseName from '../../util/baseName';
 import ResultsList from '../QueryBuilder/ResultsList';
 
@@ -103,6 +103,10 @@ function TemplatedQueryForm({ query, onSubmit, data }) {
             <Button type="submit">
               <FormattedMessage id="ui-ldp.button.submit" />
             </Button>
+            <br style={{ marginTop: '2em' }} />
+            <Accordion closedByDefault label={<FormattedMessage id="ui-ldp.devinfo" />}>
+              <pre>{JSON.stringify(query, null, 2)}</pre>
+            </Accordion>
           </form>
         )}
       </Form>

--- a/src/components/TemplatedQuery/TemplatedQueryForm.js
+++ b/src/components/TemplatedQuery/TemplatedQueryForm.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { Form, Field } from 'react-final-form';
 import { TextField, Datepicker, Select, /* AutoSuggest, */ Button } from '@folio/stripes/components';
 import baseName from '../../util/baseName';
+import ResultsList from '../QueryBuilder/ResultsList';
 
 
 function type2component(param) {
@@ -61,7 +62,7 @@ function parameterizedField(param) {
 }
 
 
-function TemplatedQueryForm({ query, onSubmit }) {
+function TemplatedQueryForm({ query, onSubmit, data }) {
   const { json, config } = query;
   const urlBase = `https://github.com/${config.user}/${config.repo}/blob/${config.branch}/${config.dir}/${query.filename}`;
 
@@ -93,6 +94,7 @@ function TemplatedQueryForm({ query, onSubmit }) {
       )}
       <Form initialValues={initialValues} onSubmit={onSubmit}>
         {({ handleSubmit }) => (
+          data ? <ResultsList results={data} /> :
           <form onSubmit={handleSubmit}>
             {json.parameters
               .filter(param => !param.disabled)
@@ -126,6 +128,7 @@ TemplatedQueryForm.propTypes = {
       ).isRequired,
     }),
   }).isRequired,
+  data: PropTypes.object,
   onSubmit: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
Closing the results list from a "Run report" query no longer clears entered parameters.

Fixes UILDP-138.