### PR TITLE
Fix "Invalid date" message in "Load query" list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Closing the results list from a "Run report" query no longer clears entered parameters. Fixes UILDP-138.
 * Support GitLab as well as GitHub as a source for templated reports. Fixes UILDP-132.
 * When there are no tables in the selected schema (e.g. because a back-end problems reports no tables at all), the UI is now robust against this condition. Fixes UILDP-151.
+* Queries that have been saved for the first time no longer show "Invalid date" in the Date Last Updated field in the Load Query list. Fixes UILDP-152.
 
 ## [2.1.0](https://github.com/folio-org/ui-ldp/tree/v2.1.0) (2024-03-19)
 

--- a/src/components/SavedQueries/ListSavedQueries.js
+++ b/src/components/SavedQueries/ListSavedQueries.js
@@ -72,7 +72,7 @@ function ListSavedQueries({ queries, deleteQuery }) {
             creator: r => <code>{r.creator}</code>,
             created: r => new Date(r.created).toLocaleString(),
             updater: r => <code>{r.updater}</code>,
-            updated: r => new Date(r.updated).toLocaleString(),
+            updated: r => r.updated ? new Date(r.updated).toLocaleString() : '',
             deleteQuery: r => <IconButton icon="trash" onClick={e => maybeDeleteQuery(e, r)} />
           }}
           onRowClick={selectQuery}
@@ -102,7 +102,7 @@ function ListSavedQueries({ queries, deleteQuery }) {
                     id="ui-ldp.saved-queries.delete.updatedBy"
                     values={{
                       updater: queryToDelete.creator,
-                      updated: new Date(queryToDelete.updated).toLocaleString(),
+                      updated: queryToDelete.updated ? new Date(queryToDelete.updated).toLocaleString() : '',
                       code: chunks => <code>{chunks}</code>,
                     }}
                   />


### PR DESCRIPTION
Queries that have been saved for the first time no longer show "Invalid date" in the Date Last Updated field in the Load Query list.

Fixes UILDP-152.