### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-ldp
 
-## [2.3.0](https://github.com/folio-org/ui-ldp/tree/v2.3.0) (IN PROGRESS)
+## [2.3.0](https://github.com/folio-org/ui-ldp/tree/v2.3.0) (2024-10-17)
 
 * When choosing a table in the Query Builder, the set of options is now filtered according to whether name includes what the user has types, not by whether the name starts with that string. Fixes UILDP-137.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/ldp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Dashboard for the Library Data Platform",
   "main": "src/index.js",
   "repository": "",


### PR DESCRIPTION
* When choosing a table in the Query Builder, the set of options is now filtered according to whether name includes what the user has types, not by whether the name starts with that string. Fixes UILDP-137.