### PR TITLE
Support `<AutoSuggest>` parameters in templated queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-ldp
 
+## [2.4.0](https://github.com/folio-org/ui-ldp/tree/v2.4.0) (IN PROGRESS)
+
+* Support `<AutoSuggest>` parameters in templated queries. Fixes UILDP-110.
+
 ## [2.3.0](https://github.com/folio-org/ui-ldp/tree/v2.3.0) (2024-10-17)
 
 * When choosing a table in the Query Builder, the set of options is now filtered according to whether name includes what the user has types, not by whether the name starts with that string. Fixes UILDP-137.

--- a/src/components/TemplatedQuery/TemplatedQueryForm.js
+++ b/src/components/TemplatedQuery/TemplatedQueryForm.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Form, Field } from 'react-final-form';
-import { TextField, Datepicker, Select, /* AutoSuggest, */ Button, Accordion } from '@folio/stripes/components';
+import { TextField, Datepicker, Select, AutoSuggest, Button, Accordion } from '@folio/stripes/components';
 import baseName from '../../util/baseName';
 import { createReportRepo } from '../../util/repoTypes';
 import ResultsList from '../QueryBuilder/ResultsList';
@@ -16,11 +16,8 @@ function type2component(param) {
     return [TextField, 'DEFAULT'];
   } else if (param['controlled.options'] && !param['controlled.allowOtherValues']) {
     return [Select, 'Select'];
-    /*
-  // For now, we don't use AutoSuggest, as it doesn't work inside a react-final-form: see UILDP-147
   } else if (param['controlled.options'] && param['controlled.allowOtherValues']) {
     return [AutoSuggest, 'AutoSuggest'];
-    */
   } else {
     return [TextField, 'TextField'];
   }


### PR DESCRIPTION
It seems the fix for the underlying `<AutoSuggest>` field in stripes-components has become available, so it's a simple matter of reinstating the commented-out code.

Fixes UILDP-110.