### PR TITLE
Allow report repository directory to be left empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support `<AutoSuggest>` parameters in templated queries. Fixes UILDP-110.
 * Recursively traverse nominated GitHub directories for reports. Fixes UILDP-104.
 * Report results are now persisted in dynamic tabs. Fixes UILDP-139.
+* Report-repository configuration now allows directory to be left blank (or specified as `/`) to indicate the top level of the repository. Fixes UILDP-156.
 
 ## [2.3.0](https://github.com/folio-org/ui-ldp/tree/v2.3.0) (2024-10-17)
 

--- a/src/util/repoTypes.js
+++ b/src/util/repoTypes.js
@@ -4,7 +4,7 @@ class QueryRepo {
     this.user = user;
     this.repo = repo;
     this.branch = branch;
-    this.dir = dir;
+    this.dir = (dir === undefined || dir === '/') ? '.' : dir;
   }
 }
 


### PR DESCRIPTION
Report-repository configuration now allows directory to be left blank (or specified as `/`) to indicate the top level of the repository.

Fixes UILDP-156.