### PR TITLE
UILDP-150 Change import of `exportToCsv` from `stripes-util` to `stripes-components`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-ldp
 
+## [2.5.0] (IN PROGRESS)
+
+* Change import of `exportToCsv` from `stripes-util` to `stripes-components`. Refs UILDP-150.
+
 ## [2.4.0](https://github.com/folio-org/ui-ldp/tree/v2.4.0) (2024-12-02)
 
 * Support `<AutoSuggest>` parameters in templated queries. Fixes UILDP-110.

--- a/src/components/QueryBuilder/ResultsList.js
+++ b/src/components/QueryBuilder/ResultsList.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, FormattedMessage } from 'react-intl';
-import { exportCsv } from '@folio/stripes/util';
-import { Button, MultiColumnList } from '@folio/stripes/components';
+import { Button, MultiColumnList, exportToCsv } from '@folio/stripes/components';
 import css from './QueryBuilder.css';
 
 
@@ -32,9 +31,9 @@ const ResultsList = ({ results, searchWithoutLimit }) => {
 
   const maybeExportCsv = (qr) => {
     if (qr.isComplete) {
-      exportCsv(qr.resp, {});
+      exportToCsv(qr.resp, {});
     } else {
-      searchWithoutLimit(r => exportCsv(r.resp, {}));
+      searchWithoutLimit(r => exportToCsv(r.resp, {}));
     }
   };
 


### PR DESCRIPTION
## Description
Use `exportToCsv` from `stripes-components` instead of a deprecated `exportCsv` from `stripes-utils`

## Issues
[UILDP-150](https://folio-org.atlassian.net/browse/UILDP-150)