### PR TITLE
[UILDP-164] Export large sets of report records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change history for ui-ldp
 
-## [3.0.0](https://github.com/folio-org/ui-ldp/tree/v3.0.0) (2025-01-17)
+## [3.0.1](https://github.com/folio-org/ui-ldp/tree/v3.0.1) (IN PROGRESS)
+
+* When running reports, large record sets (up to 10000 records) are correctly exported. Fixes UILDP-164.
+
+## [3.0.0](https://github.com/folio-org/ui-ldp/tree/v3.0.0) (2025-03-11)
 
 * **BREAKING**: upgrade to Stripes v10. Fixes UILDP-160.
 * **BREAKING**: upgrade to react-intl v7.1.5. Fixes UILDP-161.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "stripes serve stripes.config.js",
-    "start2": "stripes serve --port 3010 --okapi https://indexdata-test-okapi.folio.indexdata.com --tenant indexdata stripes.config.js",
+    "start-idtest": "stripes serve --port 3010 --okapi https://indexdata-test-okapi.folio.indexdata.com --tenant indexdata stripes.config.js",
+    "start-snapshot": "stripes serve --port 3011 --okapi https://folio-snapshot-okapi.dev.folio.org --tenant diku",
     "build": "stripes build --output ./output",
     "test-snapshot": "stripes serve --coverage --port 3001 --okapi https://folio-snapshot-okapi.dev.folio.org & pid=$! && cypress run; status=$?; kill $pid; echo Exiting with status $status; exit $status",
     "test-snapshot-load": "echo Use test-snapshot instead",

--- a/src/util/loadReport.js
+++ b/src/util/loadReport.js
@@ -26,7 +26,7 @@ const loadReport = async (intl, stripes, url, params, setQueryResponse, setError
 
   loadData(intl, stripes, 'report', '/ldp/db/reports', setData, setError, {
     method: 'POST',
-    body: JSON.stringify({ url, params, limit }),
+    body: JSON.stringify({ url, params, limit: parseInt(limit, 10) + 1 }),
   });
 };
 


### PR DESCRIPTION
When running reports, large record sets (up to 10000 records) are correctly exported