### PR TITLE
[UILDP-173] Show spinner while loading reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Recursively traverse nominated GitLab directories for reports. Fixes UILDP-157.
 * Allow for dynamic choices in a templated SQL query based on FOLIO data. Fixes UILDP-141.
 * Links from report forms to the underlying SQL queries and metadata work once more. Fixes UILDP-172.
+* While loading the list of reports, display a spinner instead of a premature empty-list message. Fixes UILDP-173.
 
 ## [3.0.2](https://github.com/folio-org/ui-ldp/tree/v3.0.2) (2025-03-19)
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "stripes serve stripes.config.js",
     "start-idtest": "stripes serve --port 3010 --okapi https://indexdata-test-okapi.folio.indexdata.com --tenant indexdata stripes.config.js",
     "start-snapshot": "stripes serve --port 3011 --okapi https://folio-snapshot-okapi.dev.folio.org --tenant diku",
+    "start-snapshot-2": "stripes serve --port 3011 --okapi https://folio-snapshot-2-okapi.dev.folio.org --tenant diku",
     "build": "stripes build --output ./output",
     "test-snapshot": "stripes serve --coverage --port 3001 --okapi https://folio-snapshot-okapi.dev.folio.org & pid=$! && cypress run; status=$?; kill $pid; echo Exiting with status $status; exit $status",
     "test-snapshot-load": "echo Use test-snapshot instead",

--- a/src/routes/TemplatedQueriesRoute.js
+++ b/src/routes/TemplatedQueriesRoute.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useStripes } from '@folio/stripes/core';
+import { Loading } from '@folio/stripes/components';
 import BigError from '../components/BigError';
 import TemplatedQueries from '../components/TemplatedQueries';
 import stripesFetch from '../util/stripesFetch';
@@ -9,6 +10,7 @@ import fetchTemplatedQueries from '../util/fetchTemplatedQueries';
 function TemplatedQueriesRoute() {
   const stripes = useStripes();
   const [error, setError] = useState();
+  const [loaded, setLoaded] = useState();
   const [gitRepos, setGitRepos] = useState();
   const [queries, setQueries] = useState([]);
 
@@ -29,7 +31,7 @@ function TemplatedQueriesRoute() {
 
   useEffect(() => {
     if (gitRepos) {
-      fetchTemplatedQueries(gitRepos, setQueries)
+      fetchTemplatedQueries(gitRepos, setLoaded, setQueries)
         .catch(e => {
           setError(e.toString());
         });
@@ -37,6 +39,7 @@ function TemplatedQueriesRoute() {
   }, [gitRepos]);
 
   if (error) return <BigError message={error} />;
+  if (!loaded) return <Loading size="large" />;
 
   return (
     <TemplatedQueries

--- a/src/util/fetchTemplatedQueries.js
+++ b/src/util/fetchTemplatedQueries.js
@@ -71,7 +71,7 @@ function mergeSQLandJSON(data) {
 }
 
 
-async function fetchTemplatedQueries(gitRepos, setQueries) {
+async function fetchTemplatedQueries(gitRepos, setLoaded, setQueries) {
   const filenamesWithConfig = await fetchTemplatedQueryFilenames(gitRepos);
 
   const promises = filenamesWithConfig.map(fc => {
@@ -106,6 +106,7 @@ async function fetchTemplatedQueries(gitRepos, setQueries) {
   const merged = mergeSQLandJSON(data);
   const withMetadata = merged.filter(x => x.json);
   withMetadata.sort((a, b) => a.json?.displayName.localeCompare(b.json?.displayName));
+  setLoaded(true);
   setQueries(withMetadata);
 }
 


### PR DESCRIPTION
While loading the list of reports, display a spinner instead of a premature empty-list message.