### PR TITLE
[UILDP-175] Switch to `@e965/xslt` for security patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Provide the ability to sort and filter the available reports. Fixes UILDP-142.
 * User can filter the reports listed on the Run Report page. Fixes UILDP-174.
 * Add support for exporting query results to Excel file. Fixes UILDP-20.
+* Switch from `xslt` dependency to maintained version `@e965/xslt` to fix security issues. Fixes UILDP-175.
 
 ## [3.0.2](https://github.com/folio-org/ui-ldp/tree/v3.0.2) (2025-03-19)
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "yakbak-proxy": "^1.7.0"
   },
   "dependencies": {
+    "@e965/xlsx": "^0.20.2",
     "chart.js": "^2.9.3",
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",
@@ -77,8 +78,7 @@
     "react-final-form-arrays": "^3.1.3",
     "react-final-form-listeners": "^1.0.2",
     "redux-form": "^8.3.0",
-    "uuid": "^8.3.1",
-    "xlsx": "^0.18.5"
+    "uuid": "^8.3.1"
   },
   "peerDependencies": {
     "@folio/stripes": "^10.0.0",

--- a/src/stripes-components/lib/ExportCsv/exportToExcel.js
+++ b/src/stripes-components/lib/ExportCsv/exportToExcel.js
@@ -1,11 +1,10 @@
-import * as XLSX from 'xlsx';
+import * as XLSX from '@e965/xlsx';
 import exportToSpreadsheet from './exportToSpreadsheet';
 
 const XLSX_MIMETYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
 export default function exportToExcel(objectArray, opts) {
   return exportToSpreadsheet(objectArray, opts, 'xlsx', 'Excel', (fields, header) => {
-    console.log('fields =', fields);
     // The mapping of our option names to those of XLSX is rather confusing!
     // See https://www.npmjs.com/package/xlsx#array-of-objects-input on inclusion of unspecified fields
     const worksheet = XLSX.utils.json_to_sheet(objectArray, { header: fields, skipHeader: !header });


### PR DESCRIPTION
Switch from the `xslt` dependency, which while maintained is no longer published to NPM, to the mirror version `@e965/xslt`. This fixes two known security issues.