### PR TITLE
[UILDP-133] Increase record-export limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * User can filter the reports listed on the Run Report page. Fixes UILDP-174.
 * Add support for exporting query results to Excel file. Fixes UILDP-20.
 * Switch from `xslt` dependency to maintained version `@e965/xslt` to fix security issues. Fixes UILDP-175.
+* Increase maximum number of records that can be exported from 100,000 to 10,000,000. Fixes UILDP-133.
 
 ## [3.0.2](https://github.com/folio-org/ui-ldp/tree/v3.0.2) (2025-03-19)
 

--- a/src/settings/RecordLimits.js
+++ b/src/settings/RecordLimits.js
@@ -94,7 +94,7 @@ function RecordLimits(props) {
                 name="maxExport"
                 label={label}
                 component={Select}
-                dataOptions={generateOptions(3, 3)}
+                dataOptions={generateOptions(3, 5)}
                 placeholder="---"
               />
             )}


### PR DESCRIPTION
Increase maximum number of records that can be exported from 100,000 to 10,000,000.

If this fails when attempted with very large sets, that will be the point to figure out why, file a specific Jira about that specific problem, and fix it. See discussion in comments of UILDP-133.