### PR TITLE
[UILDP-176] JSON-parse error messages include file URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Switch from `xslt` dependency to maintained version `@e965/xslt` to fix security issues. Fixes UILDP-175.
 * Increase maximum number of records that can be exported from 100,000 to 10,000,000. Fixes UILDP-133.
 * Defeat GitHub caching to always get up-to-date reports. Fixes UILDP-135.
+* Error message on malformed report-metadata JSON now includes the path to the faulty file. Fixes UILDP-176.
 
 ## [3.0.2](https://github.com/folio-org/ui-ldp/tree/v3.0.2) (2025-03-19)
 

--- a/src/util/fetchTemplatedQueries.js
+++ b/src/util/fetchTemplatedQueries.js
@@ -58,7 +58,13 @@ function mergeSQLandJSON(data) {
   data.forEach(entry => {
     if (entry.filename.endsWith('.json')) {
       const qn = baseName(entry.filename);
-      jsonRegister[qn] = JSON.parse(entry.text);
+      try {
+        jsonRegister[qn] = JSON.parse(entry.text);
+      } catch (e) {
+        const reportRepo = createReportRepo(entry.config);
+        const url = reportRepo.urlBase(entry.filename);
+        throw new Error(`Could not parse JSON for ${url}: ${e.toString()}`);
+      }
     }
   });
 


### PR DESCRIPTION
When failing to parse a malformed report-metadata JSON file, the error message displayed to the user now includes the path to the faulty file, so it can be fixed or removed.